### PR TITLE
Fix minor wording issue in the --ledger option description

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,6 @@ Commands:
 Options:
   --help                       Show the command's description and exit.
   --private-key           TEXT Private key to sign transactions with (only for write functionality).
-  --ledger                     Flag if to use a ledger to sign transactions (only for write functionality).
+  --ledger                     Flag to use a ledger to sign transactions (only for write functionality).
   --ledger-address        TEXT Address of the ledger's account to use to sign transactions (only for write functionality).
 ```


### PR DESCRIPTION
**Description:**

I noticed a small typo in the documentation related to the `--ledger` option under "Options." The current wording says:

> "Flag if to use a ledger to sign transactions"

This phrasing is slightly awkward and could cause confusion. The more accurate and natural way to describe it would be:

> "Flag to use a ledger to sign transactions"

This change improves clarity and ensures that the documentation is easier to understand for users who are configuring the tool for the first time.